### PR TITLE
Make formatting more consistent, some variable naming fix

### DIFF
--- a/uart.c
+++ b/uart.c
@@ -4,18 +4,20 @@
 #include "uart.h"
 
 // Dummy struct to help running the unit tests, see example code in function below.
-struct MEMORY_REGISTRY{
+struct MemoryRegistry{
 };
 
-struct MEMORY_REGISTRY mem_reg;
+struct MemoryRegistry mem_reg;
 
 // TODO: Implement a memory operation for writing to a dummy UART buffer
 void stub_memwrite(uint32_t *mem_addr, uint32_t val)
 {
-    /* Since these methods will be unit tested on ubuntu, and not the actual hardware, we need to create a 
-       dummy method to ensure that the memory is accessible. The following is an example way of doing it to ensure 
-       that the tests will pass with UART_BASE_ADDR as an input (The base address is provided in the task). Feel free
-       to change this line */
+    /* Since these methods will be unit tested on ubuntu, and not the
+       actual hardware, we need to create a dummy method to ensure
+       that the memory is accessible. The following is an example way
+       of doing it to ensure that the tests will pass with
+       UART_BASE_ADDR as an input (The base address is provided in the
+       task). Feel free to change this line */
     mem_addr = ((uint32_t*) &mem_reg + (mem_addr - (uint32_t*)UART_BASE_ADDR));
 }
 
@@ -26,7 +28,7 @@ uint32_t stub_memread(uint32_t *mem_addr)
 }
 
 // TODO: Implement the initialization function
-void init_uart(UART_HANDLE *h)
+void init_uart(uart_config *cfg)
 {
 
 }

--- a/uart.h
+++ b/uart.h
@@ -6,20 +6,23 @@
 
 #define UART_BASE_ADDR 0xFC000000
 
-// TODO Base Values, provide base values if you deem it necessary, otherwise provide them in the code
-enum BaudRate {BR_4800,BR_9600,BR_14400,BR_19200,BR_38400};
+// TODO Base Values, provide base values if you deem it necessary,
+// otherwise provide them in the code
+enum BaudRate {BR_4800, BR_9600, BR_14400, BR_19200, BR_38400};
 
-// Data structure containing UART parameters including base address and other settings
-typedef struct UART_HANDLE {
-    // TODO Just an example, fill the struct with variables of types you deem appropriate
-    enum BaudRate baudRate; 
-    
-}UART_HANDLE;
+// Data structure containing UART parameters including base address
+// and other settings
+typedef struct {
+    // TODO Just an example, fill the struct with variables of types
+    // you deem appropriate
+    enum BaudRate baud_rate;
 
-void stub_memwrite(uint32_t * mem_addr,uint32_t val);
+} uart_config;
 
-uint32_t stub_memread(uint32_t* mem_addr);
+void stub_memwrite(uint32_t *mem_addr, uint32_t val);
 
-void init_uart(UART_HANDLE* h);
+uint32_t stub_memread(uint32_t *mem_addr);
+
+void init_uart(uart_config *cfg);
 
 #endif //UART_H

--- a/uart_test.c
+++ b/uart_test.c
@@ -5,8 +5,8 @@
 
 /* Pointer to the file used by the tests. */
 
-static FILE* temp_file = NULL;
-uint32_t *baseAddress = (uint32_t *) 0xFC000000;
+static FILE *temp_file = NULL;
+uint32_t *base_address = (uint32_t *) 0xFC000000;
 
 
 /* The suite initialization function.
@@ -40,51 +40,52 @@ int clean_suite1(void)
 
 
 /* Simple tests of data written to the memory registries.
- * Same layout for all tests, check that the value assigned to the memory registry is correct
- * and that the write functions work so that we can re assign the value.
+ * Same layout for all tests, check that the value assigned to the
+ * memory registry is correct and that the write functions work so
+ * that we can re assign the value.
  */
 
 void testBRR(void)
 {
-    CU_ASSERT(stub_memread(baseAddress+0x04) == 0x1024);
-    stub_memwrite(baseAddress+0x04,0xF);
-    CU_ASSERT_FALSE(stub_memread(baseAddress+0x04)==0x1024);
+    CU_ASSERT(stub_memread(base_address + 0x04) == 0x1024);
+    stub_memwrite(base_address + 0x04,0xF);
+    CU_ASSERT_FALSE(stub_memread(base_address + 0x04)==0x1024);
 
 }
 
 void testTER(void)
 {
-    CU_ASSERT(stub_memread(baseAddress+0x08) == 0x800000);
-    stub_memwrite(baseAddress+0x08,0xF);
-    CU_ASSERT_FALSE(stub_memread(baseAddress+0x08)==0x800000);
+    CU_ASSERT(stub_memread(base_address + 0x08) == 0x800000);
+    stub_memwrite(base_address + 0x08,0xF);
+    CU_ASSERT_FALSE(stub_memread(base_address + 0x08)==0x800000);
 }
 
 void testRER(void)
 {
-    CU_ASSERT(stub_memread(baseAddress+0xC) == 0x0);
-    stub_memwrite(baseAddress+0xC,0xF);
-    CU_ASSERT_FALSE(stub_memread(baseAddress+0xC)==0x0);
+    CU_ASSERT(stub_memread(base_address + 0xC) == 0x0);
+    stub_memwrite(base_address + 0xC,0xF);
+    CU_ASSERT_FALSE(stub_memread(base_address + 0xC)==0x0);
 }
 
 void testIER(void)
 {
-    CU_ASSERT(stub_memread(baseAddress+0x10) == 0xC000);
-    stub_memwrite(baseAddress+0x10,0xF);
-    CU_ASSERT_FALSE(stub_memread(baseAddress+0x10)==0xC000);
+    CU_ASSERT(stub_memread(base_address + 0x10) == 0xC000);
+    stub_memwrite(base_address + 0x10,0xF);
+    CU_ASSERT_FALSE(stub_memread(base_address + 0x10)==0xC000);
 }
 
 void testTDR(void)
 {
-    CU_ASSERT(stub_memread(baseAddress+0x14) == 0x0);
-    stub_memwrite(baseAddress+0x14,0xF);
-    CU_ASSERT_FALSE(stub_memread(baseAddress+0x14)==0x0);
+    CU_ASSERT(stub_memread(base_address + 0x14) == 0x0);
+    stub_memwrite(base_address + 0x14,0xF);
+    CU_ASSERT_FALSE(stub_memread(base_address + 0x14)==0x0);
 }
 
 void testRDR(void)
 {
-    CU_ASSERT(stub_memread(baseAddress+0x18) == 0x0);
-    stub_memwrite(baseAddress+0x18,0xF);
-    CU_ASSERT_FALSE(stub_memread(baseAddress+0x18)==0x0);
+    CU_ASSERT(stub_memread(base_address + 0x18) == 0x0);
+    stub_memwrite(base_address + 0x18,0xF);
+    CU_ASSERT_FALSE(stub_memread(base_address + 0x18)==0x0);
 }
 
 
@@ -95,8 +96,8 @@ void testRDR(void)
  */
 int main()
 {
-    UART_HANDLE h;
-    init_uart(&h); // Initialises for UART baudate 38400,8,None,1,None
+    uart_config cfg;
+    init_uart(&cfg); // Initialises for UART baudate 38400,8,None,1,None
 
     CU_pSuite pSuite = NULL;
 


### PR DESCRIPTION
Unify format of struct/enum tags.

Reduce max column as per common guidelines.

Rename `UART_HANDLE`, since its comment says it's to "hold settings".